### PR TITLE
docs: move references of `graphql-engine:master` to `sample-apps:main`

### DIFF
--- a/gatsby-postgres-graphql/README.md
+++ b/gatsby-postgres-graphql/README.md
@@ -2,7 +2,7 @@
 
 Boilerplate to get started with Gatsby, Hasura GraphQL engine as CMS and postgres as database using the awesome plugin [gatsby-source-graphql](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-graphql).
 
-[![Edit gatsby-postgres-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/gatsby-postgres-graphql?fontsize=14)
+[![Edit gatsby-postgres-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/gatsby-postgres-graphql?fontsize=14)
 
 ![Gatsby Postgres GraphQL](./assets/gatsby-postgres-graphql.png)
 
@@ -17,8 +17,8 @@ Boilerplate to get started with Gatsby, Hasura GraphQL engine as CMS and postgre
 - Clone this repo:
 
 ```bash
-git clone https://github.com/hasura/graphql-engine
-cd graphql-engine/community/sample-apps/gatsby-postgres-graphql
+git clone https://github.com/hasura/sample-apps
+cd gatsby-postgres-graphql
 ```
 
 - Create `author` table:

--- a/gridsome-postgres-graphql/README.md
+++ b/gridsome-postgres-graphql/README.md
@@ -2,7 +2,7 @@
 
 Boilerplate to get started with Gridsome, Hasura GraphQL Engine and PostgreSQL. It uses the Hasura GraphQL Engine as a CMS, PostgreSQL as a database and the [source-graphql](https://github.com/gridsome/gridsome/tree/master/packages/source-graphql) plugin.
 
-[![Edit gridsome-postgres-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/gridsome-postgres-graphql?fontsize=14)
+[![Edit gridsome-postgres-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/gridsome-postgres-graphql?fontsize=14)
 
 ![Gridsome Postgres GraphQL](https://graphql-engine-cdn.hasura.io/assets/gridsome-postgres-graphql/gridsome-postgres-graphql.png)
 

--- a/nextjs-8-serverless/with-apollo-jwt/README.md
+++ b/nextjs-8-serverless/with-apollo-jwt/README.md
@@ -31,8 +31,8 @@ Ensure to configure Hasura GraphQL Engine with the environment variables `HASURA
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/nextjs-8-serverless/with-apollo-jwt
+  git clone https://github.com/hasura/sample-apps
+  cd nextjs-8-serverless/with-apollo-jwt
   ```
 
 - Install npm modules:

--- a/nextjs-8-serverless/with-apollo/README.md
+++ b/nextjs-8-serverless/with-apollo/README.md
@@ -27,8 +27,8 @@
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/nextjs-8-serverless/with-apollo
+  git clone https://github.com/hasura/sample-apps
+  cd nextjs-8-serverless/with-apollo
   ```
 
 - Install npm modules:

--- a/nextjs-postgres-graphql/README.md
+++ b/nextjs-postgres-graphql/README.md
@@ -40,8 +40,8 @@ Boilerplate to get started with Nextjs, Hasura GraphQL engine as CMS and postgre
 - Clone this repo:
 
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/nextjs-postgres-graphql
+  git clone https://github.com/hasura/sample-apps
+  cd nextjs-postgres-graphql
   ```
 
 - Install npm modules:

--- a/nuxtjs-postgres-graphql/README.md
+++ b/nuxtjs-postgres-graphql/README.md
@@ -2,7 +2,7 @@
 
 > Boilerplate to get started with Nuxt.js, Hasura GraphQL engine as CMS and postgres as database using the [create-nuxt-app](https://nuxtjs.org/guide/installation) and [@nuxtjs/apollo](https://github.com/nuxt-community/apollo-module) module.
 
-[![Edit nuxtjs-postgres-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/nuxtjs-postgres-graphql?fontsize=14)
+[![Edit nuxtjs-postgres-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/nuxtjs-postgres-graphql?fontsize=14)
 
 # Tutorial
 
@@ -33,8 +33,8 @@ columns: `id`, `title`, `content`, `author_id` (foreign key to `author` table's 
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/nuxtjs-postgres-graphql
+  git clone https://github.com/hasura/sample-apps
+  cd nuxtjs-postgres-graphql
   ```
 
 - Install npm modules:

--- a/quasar-framework-vue-graphql/README.md
+++ b/quasar-framework-vue-graphql/README.md
@@ -2,7 +2,7 @@
 
 A boilerplate to get started with Quasar Framework, Hasura GraphQL Engine as a CMS and Postgres as a database using the [quasar-cli](https://quasar-framework.org/guide/app-installation.html) and [vue-apollo](https://github.com/Akryum/vue-apollo) module.
 
-[![Edit quasar-framework-vue-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/quasar-framework-vue-graphql?fontsize=14)
+[![Edit quasar-framework-vue-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/quasar-framework-vue-graphql?fontsize=14)
 
 # Tutorial
 
@@ -34,8 +34,8 @@ A boilerplate to get started with Quasar Framework, Hasura GraphQL Engine as a C
 - Clone this repo:
 
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/quasar-framework-vue-graphql
+  git clone https://github.com/hasura/sample-apps
+  cd quasar-framework-vue-graphql
   ```
 
 - Install node modules:

--- a/react-apollo-todo/README.md
+++ b/react-apollo-todo/README.md
@@ -1,6 +1,6 @@
 ## Live demo
 
-[![Edit react-apollo-todo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/react-apollo-todo?fontsize=14)
+[![Edit react-apollo-todo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/react-apollo-todo?fontsize=14)
 
 - [React App](https://react-apollo-todo.demo.hasura.app/)
 - [Hasura Console](https://react-apollo-todo.hasura.app/console)

--- a/react-apollo-todo/src/components/Home/Home.js
+++ b/react-apollo-todo/src/components/Home/Home.js
@@ -145,7 +145,7 @@ class App extends Component {
           */}
           <span className="footerLinkPadd">
             <a
-              href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/react-apollo-todo"
+              href="https://github.com/hasura/sample-apps/tree/main/react-apollo-todo"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/react-static-graphql/README.md
+++ b/react-static-graphql/README.md
@@ -2,7 +2,7 @@
 
 A sample app to get started with [react-static](https://github.com/nozzle/react-static) site generator, Hasura GraphQL engine and Postgres as database.
 
-[![Edit react-static](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/react-static-graphql?fontsize=14)
+[![Edit react-static](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/react-static-graphql?fontsize=14)
 
 # Tutorial
 
@@ -37,8 +37,8 @@ columns: `id`, `title`, `content`, `author_id` (foreign key to `author` table's 
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/react-static-graphql
+  git clone https://github.com/hasura/sample-apps
+  cd react-static-graphql
   ```
 
 - Install npm modules:

--- a/realtime-chat-vue/README.md
+++ b/realtime-chat-vue/README.md
@@ -2,7 +2,7 @@
 
 This is the source code for a fully working group chat app that uses subscriptions in Hasura GraphQL Engine. It is built using Vue and Apollo.
 
-[![Edit chat-app](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/realtime-chat-vue?fontsize=14)
+[![Edit chat-app](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/realtime-chat-vue?fontsize=14)
 
 - [Fully working app](https://realtime-chat-vue.hasura.app/)
 - [Backend](https://realtime-chat.demo.hasura.io/console)

--- a/realtime-chat-vue/src/views/Home.vue
+++ b/realtime-chat-vue/src/views/Home.vue
@@ -9,7 +9,7 @@
               Backend
             </a>
             &nbsp; | &nbsp;
-            <a href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/realtime-chat-vue" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/hasura/sample-apps/tree/main/realtime-chat-vue" target="_blank" rel="noopener noreferrer">
               Source
             </a>
             &nbsp; | &nbsp;

--- a/realtime-chat/README.md
+++ b/realtime-chat/README.md
@@ -4,7 +4,7 @@ This is the source code for a fully working group chat app that uses subscriptio
 
 Run this example with Docker: `docker compose up -d --build`
 
-[![Edit chat-app](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/realtime-chat?fontsize=14)
+[![Edit chat-app](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/realtime-chat?fontsize=14)
 
 - [Fully working app](https://realtime-chat.demo.hasura.io/)
 - [Backend](https://realtime-chat.demo.hasura.io/console)

--- a/realtime-chat/src/components/Chat.js
+++ b/realtime-chat/src/components/Chat.js
@@ -47,7 +47,7 @@ function Chat(props) {
           </a>
           &nbsp; | &nbsp;
           <a
-            href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/realtime-chat"
+            href="https://github.com/hasura/sample-apps/tree/main/realtime-chat"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/realtime-location-tracking/README.md
+++ b/realtime-location-tracking/README.md
@@ -3,7 +3,7 @@
 A demo application to showcase real-time capabilities of [Hasura GraphQL
 Engine](https://github.com/hasura/graphql-engine).
 
-[![Edit realtime-location-tracking](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/realtime-location-tracking?fontsize=14)
+[![Edit realtime-location-tracking](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/realtime-location-tracking?fontsize=14)
 
 The Realtime location application is built using React and is powered by Hasura
 GraphQL Engine over Postgres. It has an interface for users to track location of a vehicle using Hasura live queries, in real-time.
@@ -24,8 +24,8 @@ hosted on GitHub pages and the Postgres+GraphQL Engine is running on Postgres.
 - Get the Hasura app URL (say `realtime-backend2.hasura.app`)
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/realtime-location-tracking
+  git clone https://github.com/hasura/sample-apps
+  cd realtime-location-tracking
   ```
 - [Install Hasura CLI](https://hasura.io/docs/latest/graphql/core/hasura-cli/install-hasura-cli.html)
 - Goto `hasura/` and edit `config.yaml`:

--- a/realtime-location-tracking/src/Vehicle/Vehicle.js
+++ b/realtime-location-tracking/src/Vehicle/Vehicle.js
@@ -142,7 +142,7 @@ function Vehicle(props) {
               Backend
             </a>
             &nbsp; | &nbsp;
-            <a href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/realtime-location-tracking" target="_blank" rel="noopener noreferrer">
+            <a href="https://github.com/hasura/sample-apps/tree/main/realtime-location-tracking" target="_blank" rel="noopener noreferrer">
               Source
             </a>
             <div className="footer-small-text">

--- a/realtime-poll/README.md
+++ b/realtime-poll/README.md
@@ -3,7 +3,7 @@
 A demo application to showcase real-time capabilities of [Hasura GraphQL
 Engine](https://github.com/hasura/graphql-engine).
 
-[![Edit realtime-poll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/realtime-poll?fontsize=14)
+[![Edit realtime-poll](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/realtime-poll?fontsize=14)
 
 The Realtime Poll application is built using React and is powered by Hasura
 GraphQL Engine over Postgres. It has an interface for users to cast vote on a
@@ -26,8 +26,8 @@ hosted on GitHub pages and the Postgres+GraphQL Engine is running on Postgres.
 - Get the Hasura app URL (say `realtime-poll.hasura.app`)
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/realtime-poll
+  git clone https://github.com/hasura/sample-apps
+  cd realtime-poll
   ```
 - [Install Hasura CLI](https://hasura.io/docs/latest/graphql/core/hasura-cli/install-hasura-cli.html)
 - Goto `hasura/` and edit `config.yaml`:

--- a/realtime-poll/src/Components.jsx
+++ b/realtime-poll/src/Components.jsx
@@ -35,7 +35,7 @@ export const Footer = () => (
       </a>
       &nbsp; | &nbsp;
       <a
-        href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/realtime-poll"
+        href="https://github.com/hasura/sample-apps/tree/main/realtime-poll"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/serverless-etl/README.md
+++ b/serverless-etl/README.md
@@ -2,16 +2,16 @@
 
 Live demo at https://serverless-etl.demo.hasura.app/
 
-[![Edit serverless-etl](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/serverless-etl?fontsize=14)
+[![Edit serverless-etl](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/serverless-etl?fontsize=14)
 
 This application demonstrates an ETL process using event triggers on [Hasura
 GraphQL Engine](https://github.com/hasura/graphql-engine).
 
 A searchable book library is shown where user can add title and author for new
 books. When a new book in inserted into the database using [GraphQL
-Mutation](https://github.com/hasura/graphql-engine/blob/master/community/sample-apps/serverless-etl/index.js#L36),
+Mutation](https://github.com/hasura/sample-apps/blob/main/serverless-etl/index.js#L36),
 a [Google Cloud
-Function](https://github.com/hasura/graphql-engine/blob/master/community/sample-apps/serverless-etl/cloudfunction/index.js)
+Function](https://github.com/hasura/sample-apps/blob/main/serverless-etl/cloudfunction/index.js)
 is triggered which updates an Algolia search index. On the search screen, user
 can search through this index and results are shown using Algolia APIs. As many
 users add more books, the search index gets bigger.

--- a/serverless-etl/index.html
+++ b/serverless-etl/index.html
@@ -78,7 +78,7 @@
             <div id="pagination"></div>
           </main>
           <div class="pt-2">
-            <a href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/serverless-etl#architecture" target="_blank">
+            <a href="https://github.com/hasura/sample-apps/tree/main/serverless-etl#architecture" target="_blank">
               <img class="col-6 img-fluid" src="arch.png" />
             </a>
           </div>
@@ -98,7 +98,7 @@
             Backend
           </a>
           &nbsp; | &nbsp;
-          <a href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/serverless-etl" target="_blank">
+          <a href="https://github.com/hasura/sample-apps/tree/main/serverless-etl" target="_blank">
             Source
           </a>
           <div class="footer-small-text"><span>(The database resets every 24 hours)</span></div>

--- a/serverless-push/README.md
+++ b/serverless-push/README.md
@@ -2,7 +2,7 @@
 
 Visit https://serverless-push.demo.hasura.app/ for a live demo.
 
-[![Edit serverless-push](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/serverless-push?fontsize=14)
+[![Edit serverless-push](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/serverless-push?fontsize=14)
 
 ## Instructions
 

--- a/serverless-push/index.html
+++ b/serverless-push/index.html
@@ -94,7 +94,7 @@
             Backend
           </a>
           &nbsp; | &nbsp;
-          <a href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/serverless-push" target="_blank">
+          <a href="https://github.com/hasura/sample-apps/tree/main/serverless-push" target="_blank">
             Source
           </a>
           <div class="footer-small-text"><span>(The database resets every 24 hours)</span></div>

--- a/streaming-subscriptions-chat/src/components/BetaAccessForm.js
+++ b/streaming-subscriptions-chat/src/components/BetaAccessForm.js
@@ -24,7 +24,7 @@ export const BetaAccessForm = (props) => {
           className="hasura-logo-img"
         />
         <a
-          href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/streaming-subscriptions-chat"
+          href="https://github.com/hasura/sample-apps/tree/main/streaming-subscriptions-chat"
           target="_blank"
           rel="noreferrer"
         >

--- a/streaming-subscriptions-chat/src/components/Chat.js
+++ b/streaming-subscriptions-chat/src/components/Chat.js
@@ -39,7 +39,7 @@ function Chat(props) {
           />
           &nbsp; | &nbsp;
           <a
-            href="https://github.com/hasura/graphql-engine/tree/master/community/sample-apps/streaming-subscriptions-chat"
+            href="https://github.com/hasura/sample-apps/tree/main/streaming-subscriptions-chat"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/svelte-apollo/README.md
+++ b/svelte-apollo/README.md
@@ -2,7 +2,7 @@
 
 A sample [Svelte 3](https://svelte.dev) app to demonstrate usage of GraphQL Queries, Mutations and Subscriptions with [svelte-apollo](https://github.com/timhall/svelte-apollo), Hasura Cloud and Postgres as database. Forked from the standard svelte [template](https://github.com/sveltejs/template)
 
-[![Edit svelte-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/svelte-apollo?fontsize=14)
+[![Edit svelte-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/svelte-apollo?fontsize=14)
 
 ## Create new Hasura Cloud project
 
@@ -36,8 +36,8 @@ columns: `id`, `title`, `content`, `author_id` (foreign key to `author` table's 
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/svelte-apollo
+  git clone https://github.com/hasura/sample-apps
+  cd svelte-apollo
   ```
 
 ## Setup App

--- a/tic-tac-toe-react/README.md
+++ b/tic-tac-toe-react/README.md
@@ -1,6 +1,6 @@
 # Multiplayer Tic Tac Toe
 
-[![Edit tic-tac-toe](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/tic-tac-toe-react/client?fontsize=14)
+[![Edit tic-tac-toe](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/tic-tac-toe-react/client?fontsize=14)
 
 This is a multiplayer tic tac toe app that uses the following components:
 

--- a/vuetify-vuex-todo-graphql/README.md
+++ b/vuetify-vuex-todo-graphql/README.md
@@ -1,7 +1,7 @@
 # vuetify-vuex-todo-graphql
 A simple Todo PWA (Progressive Web App) inspired by [TodoMVC](http://todomvc.com), [Vue.js](https://vuejs.org), [Vuex](https://vuex.vuejs.org) and [Vuetify](https://vuetifyjs.com) technologies, forked from [davidgararo/vuetify-todo-pwa](https://github.com/davidgaroro/vuetify-todo-pwa), adding Hasura GraphQL integration
 
-[![Edit vuetify-vuex-todo-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/vuetify-vuex-todo-graphql?fontsize=14)
+[![Edit vuetify-vuex-todo-graphql](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/vuetify-vuex-todo-graphql?fontsize=14)
 
 # Tutorial
 
@@ -20,8 +20,8 @@ A simple Todo PWA (Progressive Web App) inspired by [TodoMVC](http://todomvc.com
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/vuetify-vuex-todo-graphql
+  git clone https://github.com/hasura/sample-apps
+  cd vuetify-vuex-todo-graphql
   ```
 
 - Install node modules:

--- a/whatsapp-clone-typescript-react/README.md
+++ b/whatsapp-clone-typescript-react/README.md
@@ -5,7 +5,7 @@ The react client is a forked version of [urigo/whatsapp-client-react](https://gi
 - Explore the backend using [Hasura
   Console](https://whatsapp-clone.hasura.app/console).
 
-[![Edit whatsapp-clone](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/graphql-engine/tree/master/community/sample-apps/whatsapp-clone-typescript-react/react-app?fontsize=14)
+[![Edit whatsapp-clone](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/hasura/sample-apps/tree/main/whatsapp-clone-typescript-react/react-app?fontsize=14)
 
 ## Running the app yourself
 
@@ -19,8 +19,8 @@ The react client is a forked version of [urigo/whatsapp-client-react](https://gi
 
 - Clone this repo:
   ```bash
-  git clone https://github.com/hasura/graphql-engine
-  cd graphql-engine/community/sample-apps/whatsapp-clone-typescript-react
+  git clone https://github.com/hasura/sample-apps
+  cd whatsapp-clone-typescript-react
   ```
 - [Install Hasura CLI](https://hasura.io/docs/latest/graphql/core/hasura-cli/install-hasura-cli.html)
 - Apply the migrations:


### PR DESCRIPTION
The examples were removed from `graphql-engine:master` in: https://github.com/hasura/graphql-engine/commit/3d533bee6148e972c136be6eef848db36b564037

I ran `git grep sample-app`, ensured all cases were covered by `sed`, and verified the URLs and instructions.