### PR TITLE
nextjs-13: use host.docker.internal for NEXTJS_SERVER_URL

### DIFF
--- a/nextjs-13/docker-compose.yaml
+++ b/nextjs-13/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - "postgres"
     restart: always
     environment:
-      NEXTJS_SERVER_URL: http://nextjs:3000
+      NEXTJS_SERVER_URL: http://host.docker.internal:3000
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/postgres
       PG_DATABASE_URL: postgres://postgres:postgrespassword@postgres:5432/postgres
       ## enable the console served by server


### PR DESCRIPTION
Changed NEXTJS_SERVER_URL to http://host.docker.internal:3000. This special hostname host.docker.internal is used to refer to the host machine's IP address from within the Docker network. 
**By updating this value, the graphql-engine service will be able to connect to the Next.js server running on the host local machine.**